### PR TITLE
Update to timetrace v0.11.0

### DIFF
--- a/timetrace.json
+++ b/timetrace.json
@@ -1,12 +1,12 @@
 {
-    "version": "0.9.0",
+    "version": "0.11.0",
     "description": "Simple time tracking CLI",
     "license": "Apache-2.0",
     "homepage": "https://github.com/dominikbraun/timetrace",
     "architecture": {
         "64bit": {
-            "url": "https://github.com/dominikbraun/timetrace/releases/download/v0.9.0/timetrace-windows-amd64.zip",
-            "hash": "ed6b03d6c7895a4c23079332784de1f33c9d612f280fc36c13600398e7c3773a"
+            "url": "https://github.com/dominikbraun/timetrace/releases/download/v0.11.0/timetrace-windows-amd64.zip",
+            "hash": "e546ccc48ed408e035d6abafe1c5a5bc477561cb14dc59e8a14d75cd630f725c"
         }
     },
     "bin": "timetrace.exe",


### PR DESCRIPTION
This PR updates timetrace to v0.11.0.